### PR TITLE
Elements of the rib

### DIFF
--- a/vrfb_tailoring_ft_h_3d.py
+++ b/vrfb_tailoring_ft_h_3d.py
@@ -532,7 +532,7 @@ gmsh.model.mesh.generate(1)
 gmsh.model.mesh.generate(2)
 gmsh.model.mesh.generate(3)
 
-gmsh.write("vrfb_tailoring_ft_h_3d.msh")
+#gmsh.write("vrfb_tailoring_ft_h_3d_20230310.msh")
 
 gmsh.fltk.run()
 gmsh.finalize()


### PR DESCRIPTION
1) Changes in the electrode rib:
Now, the number of elements is 40. Also, the spacing is bump.

2) Mesh writing:
Unable to run the line: gmsh.write("vrfb_tailoring_ft_h_3d.msh")
Everything else, runs ok.